### PR TITLE
Transcaffeine/powerdns admin 0.4.0

### DIFF
--- a/roles/powerdns-admin/defaults/main.yml
+++ b/roles/powerdns-admin/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-powerdns_admin_version: 0.2.5
+powerdns_admin_version: 0.3.0
 powerdns_admin_user: powerdns-admin
 
 powerdns_admin_run_uid: "{{ powerdns_admin_user_info.uid if (powerdns_admin_user_info is defined) else powerdns_admin_user }}"

--- a/roles/powerdns-admin/defaults/main.yml
+++ b/roles/powerdns-admin/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-powerdns_admin_version: 0.2.4
+powerdns_admin_version: 0.2.5
 powerdns_admin_user: powerdns-admin
 
 powerdns_admin_run_uid: "{{ powerdns_admin_user_info.uid if (powerdns_admin_user_info is defined) else powerdns_admin_user }}"

--- a/roles/powerdns-admin/defaults/main.yml
+++ b/roles/powerdns-admin/defaults/main.yml
@@ -9,7 +9,7 @@ powerdns_admin_run_gid: "{{ powerdns_admin_user_info.group if (powerdns_admin_us
 powerdns_admin_base_path: "/opt/powerdns-admin"
 powerdns_admin_data_path: "/opt/powerdns-admin/data"
 
-powerdns_admin_container_image_name: "docker.io/ngoduykhanh/powerdns-admin"
+powerdns_admin_container_image_name: "docker.io/powerdnsadmin/pda-legacy"
 powerdns_admin_container_image_tag: ~
 powerdns_admin_container_image_ref: "{{ powerdns_admin_container_image_name }}:{{ powerdns_admin_container_image_tag | default('v' + powerdns_admin_version, True) }}"
 powerdns_admin_container_name: powerdns-admin


### PR DESCRIPTION
0.4.0 is no longer tagged on dockerhub: https://hub.docker.com/r/powerdnsadmin/pda-legacy/tags

-> self-build?