### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,7 +6,7 @@ on:
       - opened
 jobs:
   add-to-project:
-    uses: famedly/github-workflows/.github/workflows/add-to-project.yml@github-v1
+    uses: famedly/github-workflows/.github/workflows/add-to-project.yml@57b383862ba81dfa265bb33d492e2bbcbc96891d
     with:
       project-url: https://github.com/orgs/famedly/projects/6
     secrets: inherit

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   ansible:
-    uses: famedly/github-workflows/.github/workflows/ansible.yml@ansible-v1
+    uses: famedly/github-workflows/.github/workflows/ansible.yml@57b383862ba81dfa265bb33d492e2bbcbc96891d
     with:
       collection: famedly/dns

--- a/.github/workflows/ff-merge.yml
+++ b/.github/workflows/ff-merge.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Fast forwarding
-        uses: sequoia-pgp/fast-forward@v1
+        uses: sequoia-pgp/fast-forward@e2c6fb52f977408912b000ad4577a669f1c4f5fe
         with:
           merge: true
           comment: on-error


### PR DESCRIPTION
## Summary
- Pin all external GitHub Actions in workflows to current upstream default-branch commit SHAs.
- Includes actions discovered from every `uses:` entry in `.github/**/*.yml` and `.github/**/*.yaml`.

## Verification
- Commit is GPG-signed locally.
- CI on this PR should validate the updated action refs.